### PR TITLE
forking sched idea

### DIFF
--- a/src/bank.rs
+++ b/src/bank.rs
@@ -550,7 +550,7 @@ impl Bank {
                     .head()
                     .store_slow(false, &bootstrap_leader_id, &account);
 
-                self.leader_scheduler.write().unwrap().bootstrap_leader = bootstrap_leader_id;
+                self.live_bank_state().head().generate_root_schedule();
 
                 trace!(
                     "applied genesis payment to bootstrap leader {:?} => {:?}",
@@ -632,11 +632,10 @@ impl Bank {
             .store(confirmation, Ordering::Relaxed);
     }
 
-    pub fn get_current_leader(&self) -> Option<(Pubkey, u64)> {
-        self.leader_scheduler
-            .read()
-            .unwrap()
-            .get_scheduled_leader(self.tick_height() + 1)
+    pub fn get_current_leader(&self) -> Option<Pubkey> {
+        //TODO: "current" needs to be more specific, tpu, or specific slot
+        let id = self.live_bank_state().head().fork_id();
+        self.root_bank_state().head().compute_node(id)
     }
 }
 

--- a/src/bank_state.rs
+++ b/src/bank_state.rs
@@ -242,6 +242,14 @@ impl BankCheckpoint {
             sched.1 = next_sched;
         }
     }
+    pub fn generate_root_schedule(&self) {
+        let mut sched = self.sched.write().unwrap();
+        sched.0 = Sched::new_root_schedule(&self);
+        sched.1 = Sched::new_schedule(&self);
+    }
+    pub fn compute_node(&self, slot: u64) -> Option<Pubkey> {
+        self.sched.read().unwrap().0.compute_node(slot)
+    }
 }
 
 pub struct BankState {

--- a/src/broadcast_service.rs
+++ b/src/broadcast_service.rs
@@ -227,7 +227,7 @@ impl BroadcastService {
             ) {
                 match e {
                     Error::RecvTimeoutError(RecvTimeoutError::Disconnected) => {
-                        return BroadcastServiceReturnType::ChannelDisconnected
+                        return BroadcastServiceReturnType::ChannelDisconnected;
                     }
                     Error::RecvTimeoutError(RecvTimeoutError::Timeout) => (),
                     Error::ClusterInfoError(ClusterInfoError::NoPeers) => (), // TODO: Why are the unit-tests throwing hundreds of these?

--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -269,7 +269,7 @@ impl Fullnode {
         }
 
         // Get the scheduled leader
-        let (scheduled_leader, _) = bank
+        let scheduled_leader = bank
             .get_current_leader()
             .expect("Leader not known after processing bank");
 
@@ -397,7 +397,7 @@ impl Fullnode {
             );
 
             let new_bank = Arc::new(new_bank);
-            let (scheduled_leader, _) = new_bank
+            let scheduled_leader = new_bank
                 .get_current_leader()
                 .expect("Scheduled leader id should be calculated after rebuilding bank");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod rpc_mock;
 pub mod rpc_pubsub;
 pub mod rpc_request;
 pub mod runtime;
+pub mod sched;
 pub mod service;
 pub mod signature;
 pub mod sigverify;

--- a/src/replay_stage.rs
+++ b/src/replay_stage.rs
@@ -121,7 +121,7 @@ impl ReplayStage {
             duration_as_ms(&now.elapsed()) as usize
         );
 
-        let (current_leader, _) = bank
+        let current_leader = bank
             .get_current_leader()
             .expect("Scheduled leader should be calculated by this point");
 
@@ -157,7 +157,7 @@ impl ReplayStage {
                 ledger_entry_sender.send(entries)?;
             }
             *entry_height += entries_len;
-            let (scheduled_leader, _) = bank
+            let scheduled_leader = bank
                 .get_current_leader()
                 .expect("Scheduled leader should be calculated by this point");
 
@@ -243,7 +243,7 @@ impl ReplayStage {
                 let mut entry_height_ = entry_height;
                 let mut last_entry_id = last_entry_id;
                 loop {
-                    let (leader_id, _) = bank
+                    let leader_id = bank
                         .get_current_leader()
                         .expect("Scheduled leader should be calculated by this point");
 

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,0 +1,60 @@
+use crate::bank_state::BankCheckpoint;
+use fnv::FnvHasher;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::vote_program;
+use std::hash::Hasher;
+
+pub const REFRESH_RATE: u64 = 1000;
+
+struct Sched {
+    min_slot: u64,
+    ranks: Vec<(Pubkey, u64)>,
+}
+
+impl Sched {
+    fn should_regenerate(prev_root: u64, new_root: u64) -> bool {
+        prev_root / REFRESH_RATE != new_root / REFRESH_RATE
+    }
+
+    /// ranked leaders
+    fn new_schedule(root: &BankCheckpoint) -> Sched {
+        let accounts = root.accounts.accounts_db.read().unwrap();
+        let leaders: Vec<(Pubkey, u64)> = accounts
+            .accounts
+            .iter()
+            .filter_map(|(id, account)| {
+                if vote_program::check_id(&account.owner) {
+                    return Some((id, account.tokens));
+                }
+                None
+            })
+            .collect();
+        let start = (Pubkey::default(), 0);
+        let ranks = leaders
+            .into_iter()
+            .scan(start, |z, x| Some((x.0, z.1 + x.1)))
+            .collect();
+        let min_slot = ((root.fork_id() + REFRESH_RATE) / REFRESH_RATE) * REFRESH_RATE;
+        Sched { ranks, min_slot }
+    }
+
+    fn compute_node(&self, slot: u64) -> Option<Pubkey> {
+        if slot < self.min_slot {
+            return None;
+        }
+        let total = self.ranks.last().unwrap().1;
+        // use a stable known hasher because this MUST be the same across the entire network
+        let mut hasher = FnvHasher::with_key(self.min_slot);
+        hasher.write(&slot.to_le_bytes());
+        let random = hasher.finish();
+        let val = random % total;
+        Some(
+            self.ranks
+                .iter()
+                .skip_while(|l| val < l.1)
+                .nth(0)
+                .unwrap()
+                .0,
+        )
+    }
+}

--- a/src/vote_signer_proxy.rs
+++ b/src/vote_signer_proxy.rs
@@ -113,7 +113,7 @@ impl VoteSignerProxy {
         vote_blob_sender: &BlobSender,
     ) -> Result<()> {
         {
-            let (leader, _) = bank.get_current_leader().unwrap();
+            let leader = bank.get_current_leader().unwrap();
 
             let mut old_leader = self.last_leader.write().unwrap();
 
@@ -188,7 +188,7 @@ impl VoteSignerProxy {
 
     fn get_leader_tpu(bank: &Bank, cluster_info: &Arc<RwLock<ClusterInfo>>) -> Result<SocketAddr> {
         let leader_id = match bank.get_current_leader() {
-            Some((leader_id, _)) => leader_id,
+            Some(leader_id) => leader_id,
             None => return Err(Error::VoteError(VoteError::NoLeader)),
         };
 


### PR DESCRIPTION
simple scheduler that gets updated with the root fork as its merged

* src/sched.rd implements a scheduler generator
* BankCheckpoint::generate_root_schedule is called to initialize the first two schedulers.  Whatever the leaders are in the accounts are scheduled for the first two epochs
* Every time the root checkpoint transitions a epoch, the next epochs schedule is generated.